### PR TITLE
Fix duplicate hash method

### DIFF
--- a/knowledge_storm/interface.py
+++ b/knowledge_storm/interface.py
@@ -67,14 +67,6 @@ class Information:
         self.meta = meta if meta is not None else {}
         self.citation_uuid = -1
 
-    def __hash__(self):
-        return hash(
-            (
-                self.url,
-                tuple(sorted(self.snippets)),
-            )
-        )
-
     def __eq__(self, other):
         if not isinstance(other, Information):
             return False


### PR DESCRIPTION
## Summary
- remove redundant `__hash__` implementation in `Information`
- install deps and run minimal import test

## Testing
- `python -m py_compile $(find knowledge_storm -name '*.py' | tr '\n' ' ')`
- `pip install -r requirements.txt`
- `python -c "import knowledge_storm; print(knowledge_storm.__version__)"`
